### PR TITLE
Add font monospace for Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, ScrollView } from 'react-native';
+import { Text, ScrollView, Platform } from 'react-native';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { createStyleObject } from 'react-syntax-highlighter/dist/create-element';
 import { defaultStyle } from'react-syntax-highlighter/dist/styles';
@@ -113,7 +113,7 @@ function NativeSyntaxHighlighter({ fontFamily, fontSize, style, children, ...res
 }
 
 NativeSyntaxHighlighter.defaultProps = {
-  fontFamily: 'Menlo-Regular',
+  fontFamily: Platform.OS === 'ios' ? 'Menlo-Regular' : 'monospace',
   fontSize: 12,
   style: defaultStyle,
   PreTag: ScrollView,


### PR DESCRIPTION
Menlo-Regular cannot found in Android, use monospace for Android

I have tested on simulator, wish to accept my pull request

<img width="572" alt="snipaste20170725_151212" src="https://user-images.githubusercontent.com/3053802/28601614-cf3f2ee0-71eb-11e7-80ae-0720ec1a596a.png">
