### PR TITLE
Fix spurious console log errors (Uncaught SyntaxError: Unexpected token o in JSON at position 1)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Text, ScrollView, Platform } from 'react-native';
+import "./prism-config.js";
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import SyntaxHighlighterPrism from 'react-syntax-highlighter/prism';
 import { createStyleObject } from 'react-syntax-highlighter/create-element';

--- a/src/prism-config.js
+++ b/src/prism-config.js
@@ -1,0 +1,1 @@
+global.Prism = { disableWorkerMessageHandler: true };


### PR DESCRIPTION
On the console you'll see a lot of errors like this:
> Uncaught SyntaxError: Unexpected token o in JSON at position 1

The reason for that can be found here:
https://github.com/PrismJS/prism/issues/1303
This PR applies the recommended fix for that thread and also tried with this PR: https://github.com/conorhastings/react-native-syntax-highlighter/pull/32

The fix is to add a prism-config.js that sets
`disableWorkerMessageHandler: true`

Fixes #12