### PR TITLE
Update styles to remove for Prism

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,10 @@ const topLevelPropertiesToRemove = [
   "MozHyphens",
   "msHyphens",
   "hyphens",
-  "fontFamily"
+  "fontFamily",
+  "WebkitBoxSizing",
+  "MozBoxSizing",
+  "boxSizing"
 ];
 
 function generateNewStylesheet({ stylesheet, highlighter }) {


### PR DESCRIPTION
This fixes another error from PrismJS. Tested with "coy" style:

```
 ERROR  Warning: Failed prop type: Invalid props.style key `WebkitBoxSizing` supplied to
 `Text`.
Bad object: {
  "backgroundColor": "#fdfdfd",
  "position": "relative",
  "margin": 8,
  "overflow": "visible",
  "padding": "0",
  "WebkitBoxSizing": "border-box",
  "MozBoxSizing": "border-box",
  "boxSizing": "border-box",
  "marginBottom": 16
}
```

